### PR TITLE
0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2022-11-09
+
+### Added
+
+- Add RClone Jobs
+- Example of a changelog for a project that uses [Semantic Versioning](https://semver.org/).
+
+### Changed
+
+- RClone.run `timeout` parameter are now in the format of `wait_timeout=True` instead of `timeout=True`.
+
+## [0.2.0] - 2022-11-07
+
+### Added
+
+- Branching strategy section
+
+## [0.1.9] - 2022-11-06
+
+### Fixed
+
+- Fix GitHub Actions CI
+
+## [0.1.1] - 2022-11-06
+
+### Added
+
+- GitHub Actions CI workflow
+
+## [0.0.2] - 2022-11-05
+
+### Added
+
+- First release
+
+[0.3.0]: https://github.com/batuhan0sanli/rclone-manager/compare/0.2.0...0.3.0
+[0.2.0]: https://github.com/batuhan0sanli/rclone-manager/compare/0.1.9...0.2.0
+[0.1.9]: https://github.com/batuhan0sanli/rclone-manager/compare/0.1.1...0.1.9
+[0.1.1]: https://github.com/batuhan0sanli/rclone-manager/compare/0.0.2...0.1.1
+[0.0.2]: https://github.com/batuhan0sanli/rclone-manager/releases/tag/0.0.2

--- a/examples/basic_copy_with_timeout.py
+++ b/examples/basic_copy_with_timeout.py
@@ -6,4 +6,4 @@ dst = 'gdrive:rclone_test'
 rclone = RClone(src, dst).copy()
 
 # Rclone terminate in 10 seconds
-rclone.run(timeout=10)
+rclone.run(wait_timeout=10)

--- a/rclone_manager/__init__.py
+++ b/rclone_manager/__init__.py
@@ -1,2 +1,3 @@
 from rclone_manager.rclone import RClone
 from rclone_manager.task import RCloneTask
+from rclone_manager.job import Job

--- a/rclone_manager/job.py
+++ b/rclone_manager/job.py
@@ -1,6 +1,75 @@
+import json
+import threading
+
 from rclone_manager.rclone import RClone
 
 
 class Job(RClone):
-    def __init__(self, src, dst, *args, **kwargs):
-        super().__init__(src, dst, *args, **kwargs)
+    """
+    This class is a subclass of the RClone class, and it is used to create a job object that can be used to run a job
+    on the cluster. It has a thread that updates the job progress in real time. It also has a callback function that
+    is called when the job is finished.
+    """
+
+    def __init__(self, src, dst, callback: callable = None, *args, **kwargs):
+        super().__init__(src, dst)
+        self.update_frequency = kwargs.pop('update_frequency', '1s')
+        self.callback = callback
+        self._flags = args + ('verbose', 'use-json-log')
+        self._options = {**kwargs, **{'stats': self.update_frequency}}
+        self._thread = None
+        self._is_finished = False
+
+        self._stats = {
+            "bytes": 0,
+            "checks": 0,
+            "deletedDirs": 0,
+            "deletes": 0,
+            "elapsedTime": 0,
+            "errors": 0,
+            "eta": None,
+            "fatalError": False,
+            "renames": 0,
+            "retryError": False,
+            "speed": 0,
+            "totalBytes": 0,
+            "totalChecks": 0,
+            "totalTransfers": 0,
+            "transferTime": 0,
+            "transfers": 0
+        }
+
+    def run(self, *args, **kwargs):
+        kwargs.pop('wait', None)  # Job.run() does not support wait
+        super().run(wait=False, *args, **kwargs)
+        self._run_thread()
+        return self
+
+    def _update_stats(self):
+        for line in iter(self.process.stdout.readline, ''):
+            if line:
+                if not line.startswith('{'):
+                    continue
+                line_json = json.loads(line.rstrip())
+                stats = line_json.get('stats', {})
+                self._stats.update(stats)
+        self._is_finished = True
+        if self.callback:
+            self.callback(self)
+
+    def _run_thread(self):
+        self._thread = threading.Thread(target=self._update_stats, name=self.name + "_thread" + '_stats')
+        self._thread.start()
+        return self._thread
+
+    def terminate(self):
+        self.process.terminate()
+        self._thread.join()
+
+    @property
+    def stats(self):
+        return self._stats
+
+    @property
+    def is_finished(self):
+        return self._is_finished

--- a/rclone_manager/job.py
+++ b/rclone_manager/job.py
@@ -1,0 +1,6 @@
+from rclone_manager.rclone import RClone
+
+
+class Job(RClone):
+    def __init__(self, src, dst, *args, **kwargs):
+        super().__init__(src, dst, *args, **kwargs)

--- a/rclone_manager/rclone.py
+++ b/rclone_manager/rclone.py
@@ -5,7 +5,7 @@ class RClone:
     def __init__(self, src, dst, *args, **kwargs):
         self.src = src
         self.dst = dst
-        self.name = kwargs.pop('name', id(self))
+        self.name = kwargs.pop('name', str(id(self)))
 
         self._flags = args
         self._options = kwargs

--- a/rclone_manager/rclone.py
+++ b/rclone_manager/rclone.py
@@ -60,11 +60,11 @@ class RClone:
         self.method = "copy"
         return self
 
-    def run(self, wait=True, timeout=None):
+    def run(self, wait=True, wait_timeout=None):
         self.process = subprocess.Popen(self.cmd.split(), stdout=subprocess.PIPE, universal_newlines=True)
         if wait:
             try:
-                self.process.wait(timeout=timeout)
+                self.process.wait(timeout=wait_timeout)
             except subprocess.TimeoutExpired:
                 self.terminate()
 

--- a/rclone_manager/rclone.py
+++ b/rclone_manager/rclone.py
@@ -2,6 +2,10 @@ import subprocess
 
 
 class RClone:
+    """
+    This class is a wrapper for the rclone command line tool.
+    """
+
     def __init__(self, src, dst, *args, **kwargs):
         self.src = src
         self.dst = dst
@@ -61,7 +65,8 @@ class RClone:
         return self
 
     def run(self, wait=True, wait_timeout=None):
-        self.process = subprocess.Popen(self.cmd.split(), stdout=subprocess.PIPE, universal_newlines=True)
+        self.process = subprocess.Popen(self.cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                        universal_newlines=True)
         if wait:
             try:
                 self.process.wait(timeout=wait_timeout)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(PATH, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='rclone-manager',
-    version='0.2.0',
+    version='0.3.0',
     description='Define multiple tasks using rclone',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Added

- Add RClone Jobs
- Example of a changelog for a project that uses [Semantic Versioning](https://semver.org/).

### Changed

- RClone.run `timeout` parameter are now in the format of `wait_timeout=True` instead of `timeout=True`.
